### PR TITLE
For empty format strings, default to built-in .NET formatter

### DIFF
--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -15,29 +15,30 @@ namespace ExcelNumberFormat
 
         static public string Format(object value, NumberFormat format, CultureInfo culture)
         {
+            if (string.IsNullOrEmpty(format.FormatString))
+                return value.ToString();
+
             var node = format.GetSection(value);
 
-            if (node.Type == SectionType.Number)
+            if (node == null)
+                return "Invalid format";
+
+            switch (node.Type)
             {
-                return FormatNumber(Convert.ToDouble(value, culture), node.Number, culture);
+                case SectionType.Number:
+                    return FormatNumber(Convert.ToDouble(value, culture), node.Number, culture);
+                case SectionType.Date:
+                    return FormatDate(Convert.ToDateTime(value, culture), node.GeneralTextDateParts, culture);
+                case SectionType.General:
+                case SectionType.Text:
+                    return FormatGeneralText(Convert.ToString(value, culture), node.GeneralTextDateParts);
+                case SectionType.Exponential:
+                    return FormatExponential(Convert.ToDouble(value, culture), node, culture);
+                case SectionType.Fraction:
+                    return FormatFraction(Convert.ToDouble(value, culture), node, culture);
+                default:
+                    return "Invalid format";
             }
-            else if (node.Type == SectionType.Date)
-            {
-                return FormatDate(Convert.ToDateTime(value, culture), node.GeneralTextDateParts, culture);
-            }
-            else if (node.Type == SectionType.General || node.Type == SectionType.Text)
-            {
-                return FormatGeneralText(Convert.ToString(value, culture), node.GeneralTextDateParts);
-            }
-            else if (node.Type == SectionType.Exponential)
-            {
-                return FormatExponential(Convert.ToDouble(value, culture), node, culture);
-            }
-            else if (node.Type == SectionType.Fraction)
-            {
-                return FormatFraction(Convert.ToDouble(value, culture), node, culture);
-            }
-            return "Invalid format";
         }
 
         static string FormatGeneralText(string text, List<string> tokens)

--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -27,15 +27,20 @@ namespace ExcelNumberFormat
             {
                 case SectionType.Number:
                     return FormatNumber(Convert.ToDouble(value, culture), node.Number, culture);
+
                 case SectionType.Date:
                     return FormatDate(Convert.ToDateTime(value, culture), node.GeneralTextDateParts, culture);
+
                 case SectionType.General:
                 case SectionType.Text:
                     return FormatGeneralText(Convert.ToString(value, culture), node.GeneralTextDateParts);
+
                 case SectionType.Exponential:
                     return FormatExponential(Convert.ToDouble(value, culture), node, culture);
+
                 case SectionType.Fraction:
                     return FormatFraction(Convert.ToDouble(value, culture), node, culture);
+
                 default:
                     return "Invalid format";
             }

--- a/test/ExcelNumberFormat.Tests/Class1.cs
+++ b/test/ExcelNumberFormat.Tests/Class1.cs
@@ -812,5 +812,20 @@ namespace ExcelNumberFormat.Tests
             TestValid("yyyy\\-mm\\-dd\\Thh:mm");
             TestValid("yyyy\\-mm\\-dd\\Thhmmss.000");
         }
+
+        [TestMethod]
+        public void TestEmptyFormatString()
+        {
+            string result;
+
+            result = Format(1234.56, string.Empty, CultureInfo.InvariantCulture);
+            Assert.AreEqual("1234.56", result);
+
+            result = Format(Double.MaxValue, string.Empty, CultureInfo.InvariantCulture);
+            Assert.AreEqual("1.79769313486232E+308", result);
+
+            result = Format(new DateTime(2017, 10, 28), string.Empty, CultureInfo.InvariantCulture);
+            Assert.AreEqual("2017-10-28 00:00:00", result);
+        }
     }
 }


### PR DESCRIPTION
Currently, if you pass an empty format string, an exception is raised. I would expect that some default format would be used. I don't think this should necessarily be what Excel would use as a default. I think the build-in .NET `ToString()` method is just fine, but you'll have to say whether this fits in with what you expect.

So this PR:
- returns default .NET format of value
- reworks the logic a bit from multiple `if` statements to a `switch` statement.