### PR TITLE
Throw exception when invalid format is used.

### DIFF
--- a/src/ExcelNumberFormat/Exceptions/InvalidExcelNumberFormatException.cs
+++ b/src/ExcelNumberFormat/Exceptions/InvalidExcelNumberFormatException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace ExcelNumberFormat.Exceptions
+{
+    public class InvalidExcelNumberFormatException : Exception
+    {
+        public InvalidExcelNumberFormatException()
+        { }
+
+        public InvalidExcelNumberFormatException(string message)
+            : this(message, null)
+        { }
+
+        public InvalidExcelNumberFormatException(string message, Exception innerException)
+        : base(message, innerException)
+        { }
+    }
+}

--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ExcelNumberFormat.Exceptions;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -16,6 +17,9 @@ namespace ExcelNumberFormat
         static public string Format(object value, NumberFormat format, CultureInfo culture)
         {
             var node = format.GetSection(value);
+
+            if (node == null)
+                throw new InvalidExcelNumberFormatException(string.Format("The format '{0}' is an invalid Excel number format.", format.FormatString));
 
             if (node.Type == SectionType.Number)
             {
@@ -37,7 +41,8 @@ namespace ExcelNumberFormat
             {
                 return FormatFraction(Convert.ToDouble(value, culture), node, culture);
             }
-            return "Invalid format";
+
+            throw new InvalidExcelNumberFormatException(string.Format("The format '{0}' is an invalid Excel number format.", format.FormatString));
         }
 
         static string FormatGeneralText(string text, List<string> tokens)

--- a/test/ExcelNumberFormat.Tests/Class1.cs
+++ b/test/ExcelNumberFormat.Tests/Class1.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using ExcelNumberFormat.Exceptions;
 using NUnit.Framework;
 using TestClass = NUnit.Framework.TestFixtureAttribute;
 using TestMethod = NUnit.Framework.TestAttribute;
@@ -357,7 +358,6 @@ namespace ExcelNumberFormat.Tests
             TestComma(123456789012, "123.4568", "123456.7890", "123456789.0120", "123,456,789,012.0", "123,456,789,012", "123,456,789,012", "123,456,789,012.00");
             TestComma(4321, ".0000", ".0043", "4.3210", "4,321.0", "4,321", "4,321", "4,321.00");
             TestComma(4321234, ".0043", "4.3212", "4321.2340", "4,321,234.0", "4,321,234", "4,321,234", "4,321,234.00");
-
         }
 
         void TestValid(string format)
@@ -811,6 +811,16 @@ namespace ExcelNumberFormat.Tests
             TestValid("yyyy\\-mm\\-dd\\ h:mm");
             TestValid("yyyy\\-mm\\-dd\\Thh:mm");
             TestValid("yyyy\\-mm\\-dd\\Thhmmss.000");
+        }
+
+        [TestMethod]
+        public void TestInvalid()
+        {
+            Assert.Throws<InvalidExcelNumberFormatException>(() =>
+            {
+                var format = new NumberFormat("JHGKJG");
+                format.Format(12345, CultureInfo.InvariantCulture);
+            });
         }
     }
 }


### PR DESCRIPTION
I think it's better to throw a library-specific exception when an invalid format is used, instead of returning a hardcoded string. It should be up to the user to treat the exception.