### PR TITLE
Fix thousands separator

### DIFF
--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -371,7 +371,7 @@ namespace ExcelNumberFormat
 
                     FormatPlaceholder(token, c, significant, result);
 
-                    if (thousandSeparator && (significant || Token.IsSignificantPlaceholder(token)))
+                    if (thousandSeparator && (significant || token.Equals("0")))
                         FormatThousandSeparator(valueString, digitIndex, culture, result);
 
                     digitIndex++;

--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -371,7 +371,7 @@ namespace ExcelNumberFormat
 
                     FormatPlaceholder(token, c, significant, result);
 
-                    if (significant && thousandSeparator)
+                    if (thousandSeparator && (significant || Token.IsSignificantPlaceholder(token)))
                         FormatThousandSeparator(valueString, digitIndex, culture, result);
 
                     digitIndex++;

--- a/src/ExcelNumberFormat/Token.cs
+++ b/src/ExcelNumberFormat/Token.cs
@@ -56,11 +56,6 @@ namespace ExcelNumberFormat
             return token == "0" || token == "#" || token == "?";
         }
 
-        public static bool IsSignificantPlaceholder(string token)
-        {
-            return token == "0";
-        }
-
         public static bool IsGeneral(string token)
         {
             return string.Compare(token, "general", StringComparison.OrdinalIgnoreCase) == 0;

--- a/src/ExcelNumberFormat/Token.cs
+++ b/src/ExcelNumberFormat/Token.cs
@@ -56,6 +56,11 @@ namespace ExcelNumberFormat
             return token == "0" || token == "#" || token == "?";
         }
 
+        public static bool IsSignificantPlaceholder(string token)
+        {
+            return token == "0";
+        }
+
         public static bool IsGeneral(string token)
         {
             return string.Compare(token, "general", StringComparison.OrdinalIgnoreCase) == 0;

--- a/test/ExcelNumberFormat.Tests/Class1.cs
+++ b/test/ExcelNumberFormat.Tests/Class1.cs
@@ -423,6 +423,13 @@ namespace ExcelNumberFormat.Tests
 
         }
 
+        [TestMethod]
+        public void TestThousandSeparator()
+        {
+            var actual = Format(1469.07, "0,000,000.00", CultureInfo.InvariantCulture);
+            Assert.AreEqual("0,001,469.07", actual);
+        }
+
         void TestValid(string format)
         {
             var to = new NumberFormat(format);


### PR DESCRIPTION
Found a case that isn't handled correctly with regards to thousands separator. Hope you agree with this fix.

```c#
public void TestThousandSeparator()
{
    var actual = Format(1469.07, "0,000,000.00", CultureInfo.InvariantCulture);
    Assert.AreEqual("0,001,469.07", actual);
}
```