### PR TITLE
Implement parser for currencies

### DIFF
--- a/src/ExcelNumberFormat/Parser.cs
+++ b/src/ExcelNumberFormat/Parser.cs
@@ -72,6 +72,8 @@ namespace ExcelNumberFormat
                         condition = parseCondition;
                     else if (TryParseColor(expression, out var parseColor))
                         color = parseColor;
+                    else if (TryParseCurrencySymbol(expression, out var parseCurrencySymbol))
+                        tokens.Add("\"" + parseCurrencySymbol + "\"");
                 }
                 else
                 {
@@ -373,6 +375,24 @@ namespace ExcelNumberFormat
 
             color = null;
             return false;
+        }
+
+        private static bool TryParseCurrencySymbol(string token, out string currencySymbol)
+        {
+            if (string.IsNullOrEmpty(token)
+                || !token.StartsWith("$"))
+            {
+                currencySymbol = null;
+                return false;
+            }
+
+
+            if (token.Contains("-"))
+                currencySymbol = token.Substring(1, token.IndexOf('-') - 1);
+            else
+                currencySymbol = token.Substring(1);
+
+            return true;
         }
     }
 }

--- a/test/ExcelNumberFormat.Tests/Class1.cs
+++ b/test/ExcelNumberFormat.Tests/Class1.cs
@@ -900,5 +900,12 @@ namespace ExcelNumberFormat.Tests
             result = Format(new DateTime(2017, 10, 28), string.Empty, CultureInfo.InvariantCulture);
             Assert.AreEqual("10/28/2017 00:00:00", result);
         }
+
+        [TestMethod]
+        public void TestCurrency()
+        {
+            Test(1234.56, "[$€-1809]# ##0.00", "€1 234.56");
+            Test(1234.56, "#,##0.00 [$EUR]", "1,234.56 EUR");
+        }
     }
 }


### PR DESCRIPTION
Parses currency tokens, e.g. `#,##0.00 [$EUR]` and treats them as a simple literal token. Nothing special done about them.