### PR TITLE
Fix DateTime formatting with uppercase formatCode

### DIFF
--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -272,7 +272,7 @@ namespace ExcelNumberFormat
             for (var i = fromIndex; i < tokens.Count; i++)
             {
                 var token = tokens[i];
-                if (token.StartsWith(startsWith))
+                if (token.StartsWith(startsWith, StringComparison.OrdinalIgnoreCase))
                     return true;
                 if (Token.IsDatePart(token))
                     return false;
@@ -286,7 +286,7 @@ namespace ExcelNumberFormat
             for (var i = fromIndex; i >= 0; i--)
             {
                 var token = tokens[i];
-                if (token.StartsWith(startsWith))
+                if (token.StartsWith(startsWith, StringComparison.OrdinalIgnoreCase))
                     return true;
                 if (Token.IsDatePart(token))
                     return false;


### PR DESCRIPTION
Use case-insensitive comparison when checking "m" codes for month/minute difference.
This corrects DateTime formatting when xlsx "formatCode" attrube is uppercase (e.g. HH:MM:SS)
otherwise the date is formatted with the month part in place of the minutes part.
