### PR TITLE
Fix for date times being formatted 24hr instead of 12hr when AM/PM exists.

### DIFF
--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -129,6 +129,7 @@ namespace ExcelNumberFormat
 
         private static string FormatDate(DateTime date, List<string> tokens, CultureInfo culture)
         {
+            var containsAmPm = tokens.Contains("AM/PM") || tokens.Contains("A/P");
             var result = new StringBuilder();
             for (var i = 0; i < tokens.Count; i++)
             {
@@ -200,7 +201,10 @@ namespace ExcelNumberFormat
                 else if (token.StartsWith("h", StringComparison.OrdinalIgnoreCase))
                 {
                     var digits = token.Length;
-                    result.Append(date.Hour.ToString("D" + digits));
+                    if(containsAmPm)
+                        result.Append(date.ToString("%h"));
+                    else
+                        result.Append(date.Hour.ToString("D" + digits));
                 }
                 else if (token.StartsWith("s", StringComparison.OrdinalIgnoreCase))
                 {
@@ -234,7 +238,7 @@ namespace ExcelNumberFormat
                 }
                 else if (string.Compare(token, "a/p", StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    var ampm = date.ToString("t", CultureInfo.InvariantCulture);
+                    var ampm = date.ToString("%t", CultureInfo.InvariantCulture);
                     if (char.IsUpper(token[0]))
                     {
                         result.Append(ampm.ToUpperInvariant());

--- a/test/ExcelNumberFormat.Tests/Class1.cs
+++ b/test/ExcelNumberFormat.Tests/Class1.cs
@@ -130,6 +130,9 @@ namespace ExcelNumberFormat.Tests
             Test(new DateTime(2010, 9, 26), "m/d/yy", "9/26/10");
             Test(new DateTime(2010, 9, 26, 12, 34, 56, 123), "m/d/yy hh:mm:ss.000", "9/26/10 12:34:56.123");
             Test(new DateTime(2010, 9, 26, 12, 34, 56, 123), "YYYY-MM-DD HH:MM:SS", "2010-09-26 12:34:56");
+            Test(new DateTime(2020, 1, 1, 14, 35, 55), "m/d/yyyy\\ h:mm:ss AM/PM;@", "1/1/2020 2:35:55 PM");
+            Test(new DateTime(2020, 1, 1, 14, 35, 55), "m/d/yyyy\\ h:mm:ss A/P;@", "1/1/2020 2:35:55 P");
+            Test(new DateTime(2020, 1, 1, 14, 35, 55), "m/d/yyyy\\ h:mm:ss;@", "1/1/2020 14:35:55");
         }
 
         [TestMethod]

--- a/test/ExcelNumberFormat.Tests/ExcelNumberFormat.Tests.csproj
+++ b/test/ExcelNumberFormat.Tests/ExcelNumberFormat.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#17 

Checks for AM/PM existence at the beginning of the formatting. If we have an AM/PM or A/P token then format the `h` component as 12 hr `%h`.

Also fixes an issue where A/P wasn't being shown correctly; `%t`.

Added some extra test cases that cover AM/PM and 12hr. 

Updated to .Net Core 2.0 since 1.0 is EOL.