### PR TITLE
Explicitly specify precision when formatting floating-point numbers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: build-{build}
 skip_tags: true
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 build_script:
 - ps: |-

--- a/src/ExcelNumberFormat/CompatibleConvert.cs
+++ b/src/ExcelNumberFormat/CompatibleConvert.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace ExcelNumberFormat
+{
+    internal static class CompatibleConvert
+    {
+        /// <summary>
+        /// A backward-compatible version of <see cref="Convert.ToString(object, IFormatProvider)"/>.
+        /// Starting from .net Core 3.0 the default precision used for formatting floating point number has changed.
+        /// To always format numbers the same way, no matter what version of runtime is used, we specify the precision explicitly.
+        /// </summary>
+        public static string ToString(object value, IFormatProvider provider)
+        {
+            switch (value)
+            {
+                case double d:
+                    return d.ToString("G15", provider);
+                case float f:
+                    return f.ToString("G7", provider);
+                default:
+                    return Convert.ToString(value, provider);
+            }
+        }
+    }
+}

--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -11,11 +11,11 @@ namespace ExcelNumberFormat
         {
             var format = new NumberFormat(formatString);
             if (!format.IsValid)
-                return Convert.ToString(value, culture);
+                return CompatibleConvert.ToString(value, culture);
 
             var section = Evaluator.GetSection(format.Sections, value);
             if (section == null)
-                return Convert.ToString(value, culture);
+                return CompatibleConvert.ToString(value, culture);
 
             return Format(value, section, culture);
         }
@@ -40,7 +40,7 @@ namespace ExcelNumberFormat
 
                 case SectionType.General:
                 case SectionType.Text:
-                    return FormatGeneralText(Convert.ToString(value, culture), node.GeneralTextDateDurationParts);
+                    return FormatGeneralText(CompatibleConvert.ToString(value, culture), node.GeneralTextDateDurationParts);
 
                 case SectionType.Exponential:
                     return FormatExponential(Convert.ToDouble(value, culture), node, culture);

--- a/src/ExcelNumberFormat/NumberFormat.cs
+++ b/src/ExcelNumberFormat/NumberFormat.cs
@@ -63,7 +63,17 @@ namespace ExcelNumberFormat
         public string Format(object value, CultureInfo culture)
         {
             if (!IsValid || string.IsNullOrEmpty(FormatString))
-                return Convert.ToString(value, culture);
+            {
+                switch (value)
+                {
+                    case double d:
+                        return d.ToString("G15", culture);
+                    case Single s:
+                        return s.ToString("G7", culture);
+                    default:
+                        return Convert.ToString(value, culture);
+                }
+            }
 
             var section = Evaluator.GetSection(Sections, value);
             if (section == null)

--- a/src/ExcelNumberFormat/NumberFormat.cs
+++ b/src/ExcelNumberFormat/NumberFormat.cs
@@ -63,21 +63,11 @@ namespace ExcelNumberFormat
         public string Format(object value, CultureInfo culture)
         {
             if (!IsValid || string.IsNullOrEmpty(FormatString))
-            {
-                switch (value)
-                {
-                    case double d:
-                        return d.ToString("G15", culture);
-                    case Single s:
-                        return s.ToString("G7", culture);
-                    default:
-                        return Convert.ToString(value, culture);
-                }
-            }
+                CompatibleConvert.ToString(value, culture);
 
             var section = Evaluator.GetSection(Sections, value);
             if (section == null)
-                return Convert.ToString(value, culture);
+                return CompatibleConvert.ToString(value, culture);
 
             try
             {
@@ -86,12 +76,12 @@ namespace ExcelNumberFormat
             catch (InvalidCastException)
             {
                 // TimeSpan cast exception
-                return Convert.ToString(value, culture);
+                return CompatibleConvert.ToString(value, culture);
             }
             catch (FormatException)
             {
                 // Convert.ToDouble/ToDateTime exceptions
-                return Convert.ToString(value, culture);
+                return CompatibleConvert.ToString(value, culture);
             }
         }
     }

--- a/src/ExcelNumberFormat/Tokenizer.cs
+++ b/src/ExcelNumberFormat/Tokenizer.cs
@@ -14,7 +14,7 @@ namespace ExcelNumberFormat
 
         public int Position => formatStringPosition;
 
-        public int Length => formatString.Length;
+        public int Length => formatString?.Length ?? 0;
 
         public string Substring(int startIndex, int length)
         {
@@ -23,7 +23,7 @@ namespace ExcelNumberFormat
 
         public int Peek(int offset = 0)
         {
-            if (formatStringPosition + offset >= formatString.Length)
+            if (formatStringPosition + offset >= Length)
                 return -1;
             return formatString[formatStringPosition + offset];
         }
@@ -82,7 +82,7 @@ namespace ExcelNumberFormat
 
         public bool ReadString(string s, bool ignoreCase = false)
         {
-            if (formatStringPosition + s.Length > formatString.Length)
+            if (formatStringPosition + s.Length > Length)
                 return false;
 
             for (var i = 0; i < s.Length; i++)

--- a/test/ExcelNumberFormat.Tests/Class1.cs
+++ b/test/ExcelNumberFormat.Tests/Class1.cs
@@ -922,6 +922,9 @@ namespace ExcelNumberFormat.Tests
             result = Format(Double.MaxValue, string.Empty, CultureInfo.InvariantCulture);
             Assert.AreEqual("1.79769313486232E+308", result);
 
+            result = Format(float.MaxValue, string.Empty, CultureInfo.InvariantCulture);
+            Assert.AreEqual("3.402823E+38", result);
+
             result = Format(new DateTime(2017, 10, 28), string.Empty, new CultureInfo("sv-se"));
             Assert.AreEqual("2017-10-28 00:00:00", result);
 

--- a/test/ExcelNumberFormat.Tests/Class1.cs
+++ b/test/ExcelNumberFormat.Tests/Class1.cs
@@ -911,24 +911,26 @@ namespace ExcelNumberFormat.Tests
             TestValid("yyyy\\-mm\\-dd\\Thhmmss.000");
         }
 
-        [TestMethod]
-        public void TestEmptyFormatString()
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("General")]
+        public void TestDefaultFormatString(string formatString)
         {
             string result;
 
-            result = Format(1234.56, string.Empty, CultureInfo.InvariantCulture);
+            result = Format(1234.56, formatString, CultureInfo.InvariantCulture);
             Assert.AreEqual("1234.56", result);
 
-            result = Format(Double.MaxValue, string.Empty, CultureInfo.InvariantCulture);
+            result = Format(Double.MaxValue, formatString, CultureInfo.InvariantCulture);
             Assert.AreEqual("1.79769313486232E+308", result);
 
-            result = Format(float.MaxValue, string.Empty, CultureInfo.InvariantCulture);
+            result = Format(float.MaxValue, formatString, CultureInfo.InvariantCulture);
             Assert.AreEqual("3.402823E+38", result);
 
-            result = Format(new DateTime(2017, 10, 28), string.Empty, new CultureInfo("sv-se"));
+            result = Format(new DateTime(2017, 10, 28), formatString, new CultureInfo("sv-se"));
             Assert.AreEqual("2017-10-28 00:00:00", result);
 
-            result = Format(new DateTime(2017, 10, 28), string.Empty, CultureInfo.InvariantCulture);
+            result = Format(new DateTime(2017, 10, 28), formatString, CultureInfo.InvariantCulture);
             Assert.AreEqual("10/28/2017 00:00:00", result);
         }
 

--- a/test/ExcelNumberFormat.Tests/ExcelNumberFormat.Tests.csproj
+++ b/test/ExcelNumberFormat.Tests/ExcelNumberFormat.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ExcelNumberFormat.Tests/ExcelNumberFormat.Tests.csproj
+++ b/test/ExcelNumberFormat.Tests/ExcelNumberFormat.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Explicitly specify precision when formatting floating-point numbers for backward compatibility with pre-Core3.0 versions of .Net

Fixes #20