### PR TITLE
Fixing issue when Fraction is >= int.MaxValue

### DIFF
--- a/src/ExcelNumberFormat/ExcelNumberFormat.csproj
+++ b/src/ExcelNumberFormat/ExcelNumberFormat.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net20;netstandard1.0;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>.NET library to parse ECMA-376 number format strings and format values like Excel and other spreadsheet softwares.</Description>

--- a/src/ExcelNumberFormat/Formatter.cs
+++ b/src/ExcelNumberFormat/Formatter.cs
@@ -528,14 +528,14 @@ namespace ExcelNumberFormat
 
         static string FormatFraction(double value, Section format, CultureInfo culture)
         {
-            int integral = 0;
+            long integral = 0;
             int numerator, denominator;
 
             bool sign = value < 0;
 
             if (format.Fraction.IntegerPart != null)
             {
-                integral = (int)Math.Truncate(value);
+                integral = (long)Math.Truncate(value);
                 value = Math.Abs(value - integral);
             }
 

--- a/test/ExcelNumberFormat.Tests/Class1.cs
+++ b/test/ExcelNumberFormat.Tests/Class1.cs
@@ -327,6 +327,8 @@ namespace ExcelNumberFormat.Tests
 
             Test(0, "0", "0");
 
+            Test((double)int.MaxValue, "# ?/?", $"{int.MaxValue}    ");
+            Test((double)int.MaxValue + 1, "# ?/?", $"{(long)int.MaxValue + 1}    ");
         }
 
         void TestExponents(double value, string expected1, string expected2, string expected3, string expected4)


### PR DESCRIPTION
Fixing issue when an excel cell is formatted as "Fraction" and the value is greater than int.MaxValue (2,147,483,647).  Prior to this fix, a value greater than int.MaxValue throws the error "System.OverflowException: Negating the minimum value of a twos complement number is invalid."