### PR TITLE
Fix issue when fromat string starts with [$-F800] and [$-F400]

### DIFF
--- a/src/ExcelNumberFormat/Section.cs
+++ b/src/ExcelNumberFormat/Section.cs
@@ -19,5 +19,7 @@ namespace ExcelNumberFormat
         public DecimalSection Number { get; set; }
 
         public List<string> GeneralTextDateDurationParts { get; set; }
+
+        public WindowsLanguageCodeIdentifier Lcid { get; set; }
     }
 }

--- a/src/ExcelNumberFormat/WindowsLanguageCodeIdentifier.cs
+++ b/src/ExcelNumberFormat/WindowsLanguageCodeIdentifier.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace ExcelNumberFormat
+{
+    /// <summary>
+    /// Represents a Windows Language Code Identifier (LCID) as defined by [MS-LCID] (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/70feba9f-294e-491e-b6eb-56532684c37f)
+    /// </summary>
+    internal class WindowsLanguageCodeIdentifier
+    {
+        public int LocaleId { get; set; }
+
+        public bool IsLongSystemDate => LocaleId == 0xF800;
+
+        public bool IsLongSystemTime => LocaleId == 0xF400;
+
+        /// <summary>
+        /// If IsLongSystemTime is true, then contains the tokens for the time formatter.
+        /// </summary>
+        public List<string> TimeTokens { get; set; }
+    }
+}

--- a/test/ExcelNumberFormat.Tests/Class1.cs
+++ b/test/ExcelNumberFormat.Tests/Class1.cs
@@ -110,6 +110,7 @@ namespace ExcelNumberFormat.Tests
             Assert.IsTrue(IsDateFormatString("mm:ss"));
             Assert.IsTrue(IsDateFormatString("mm:ss.0"));
             Assert.IsTrue(IsDateFormatString("[$-809]dd mmmm yyyy"));
+            Assert.IsTrue(IsDateFormatString(@"[$-F800]dddd\,\ mmmm\ dd\,\ yyyy"));
             Assert.IsFalse(IsDateFormatString("#,##0;[Red]-#,##0"));
             Assert.IsFalse(IsDateFormatString("0_);[Red](0)"));
             Assert.IsFalse(IsDateFormatString(@"0\h"));
@@ -143,6 +144,9 @@ namespace ExcelNumberFormat.Tests
             Test(new DateTime(2017, 10, 16, 0, 0, 0), "dddd,,, MMMM d,, yyyy,,,,", "Monday, October 16, 2017,");
             Test(new DateTime(2020, 1, 1, 0, 35, 55), "m/d/yyyy\\ hh:mm:ss AM/PM;@", "1/1/2020 12:35:55 AM");
             Test(new DateTime(2020, 1, 1, 12, 35, 55), "m/d/yyyy\\ hh:mm:ss AM/PM;@", "1/1/2020 12:35:55 PM");
+            Test(new DateTime(2017, 10, 16, 0, 0, 0), "[$-F800]m/d/yyyy\\ h:mm:ss a/P;@", "Monday, 16 October 2017");
+            Test(new DateTime(2017, 10, 16, 0, 0, 0), @"[$-F800]dddd\,\ mmmm\ dd\,\ yyyy", "Monday, 16 October 2017");
+            TestWithCulture(new CultureInfo("Fr-fr"), new DateTime(2017, 10, 16, 0, 0, 0), @"[$-F800]dddd\,\ mmmm\ dd\,\ yyyy", "lundi 16 octobre 2017");
         }
 
         [TestMethod]
@@ -192,11 +196,18 @@ namespace ExcelNumberFormat.Tests
             Test(new TimeSpan(0, -2, -31, -45), "[hh]:mm:ss", "-02:31:45");
             Test(new TimeSpan(0, -2, -31, -44, -500), "[hh]:mm:ss", "-02:31:45");
             Test(new TimeSpan(0, -2, -31, -44, -500), "[hh]:mm:ss.000", "-02:31:44.500");
+            Test(new TimeSpan(1, 2, 31, 44, 500), @"[$-F400]h:mm:ss\ AM/PM", "1.02:31:44.5000000");
+            TestWithCulture(new CultureInfo("Fr-fr"),new TimeSpan(1, 2, 31, 44, 500), @"[$-F400]h:mm:ss\ AM/PM", "1.02:31:44.5000000");
         }
 
         void Test(object value, string format, string expected, bool isDate1904 = false)
         {
-            var result = Format(value, format, CultureInfo.InvariantCulture, isDate1904);
+            TestWithCulture(CultureInfo.InvariantCulture, value, format, expected, isDate1904);
+        }
+
+        void TestWithCulture(CultureInfo culture, object value, string format, string expected, bool isDate1904 = false)
+        {
+            var result = Format(value, format, culture, isDate1904);
             Assert.AreEqual(expected, result);
         }
 


### PR DESCRIPTION
Fix bug described in issue #41 where the formatted date was incorrect when the format started with "[$-F800]".

Even if not really documented (or very hard to find), locale id F800 seems to refer to the system long date.
This PR adds code to parse totally the locale id, and use it in the parser for date and time.

When parsing the date, if the locale id is F800, then the culture LongDatePattern is used instead of the tokens found with the tokeniser.

When parsing the date, the tokens are replaced with tokens generated from the culture LongTimePattern.